### PR TITLE
Add dual registry mirroring for GHCR and Quay.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,19 +18,32 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Log in to Container Registry
+    # Login to GitHub Container Registry
+    - name: Log in to GitHub Container Registry
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # Login to Quay.io
+    - name: Log in to Quay.io
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    # Extract metadata for tagging
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: |
+          ghcr.io/karlssoc/ck-pybis-toolkit
+          quay.io/karlssoc/ck-pybis-toolkit
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -42,6 +51,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable={{is_default_branch}}
 
+    # Build and push to both registries
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
@@ -51,4 +61,5 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           BUILDKIT_SYNTAX=docker/dockerfile:1.4
+        # Ensure Docker V2 Schema 2 format compatibility
         provenance: false

--- a/docs/QUAY_SECRETS_SETUP.md
+++ b/docs/QUAY_SECRETS_SETUP.md
@@ -1,0 +1,89 @@
+# Quay.io Registry Secrets Setup
+
+This document explains how to configure repository secrets for dual registry pushing to both GitHub Container Registry (GHCR) and Quay.io.
+
+## Required Secrets
+
+To enable container mirroring to Quay.io, the following repository secrets must be configured:
+
+### 1. QUAY_USERNAME
+- **Name:** `QUAY_USERNAME`
+- **Value:** `karlssoc`
+- **Description:** Username for the Quay.io registry account
+
+### 2. QUAY_PASSWORD
+- **Name:** `QUAY_PASSWORD`
+- **Value:** [Quay.io password or application token]
+- **Description:** Authentication token for Quay.io registry access
+
+## Setup Instructions
+
+### Step 1: Access Repository Settings
+1. Navigate to the repository: https://github.com/karlssoc/ck-pybis-toolkit
+2. Click on **Settings** tab
+3. In the left sidebar, click **Secrets and variables** → **Actions**
+
+### Step 2: Add Quay.io Username
+1. Click **New repository secret**
+2. Enter name: `QUAY_USERNAME`
+3. Enter value: `karlssoc`
+4. Click **Add secret**
+
+### Step 3: Add Quay.io Password/Token
+1. Click **New repository secret**
+2. Enter name: `QUAY_PASSWORD`
+3. Enter your Quay.io password or application token
+4. Click **Add secret**
+
+## Security Recommendations
+
+### Use Application Tokens (Recommended)
+Instead of using your account password, create a dedicated application token:
+
+1. Log in to [quay.io](https://quay.io)
+2. Go to **Account Settings** → **Robot Accounts**
+3. Create a new robot account with push permissions to `karlssoc/ck-pybis-toolkit`
+4. Use the robot account token as `QUAY_PASSWORD`
+
+### Minimal Permissions
+The token should have only the necessary permissions:
+- **Repository:** `karlssoc/ck-pybis-toolkit`
+- **Permissions:** Write (push containers)
+
+## Verification
+
+After configuring the secrets, you can verify the setup by:
+
+1. **Triggering a workflow:** Push to the `main` branch or create a release
+2. **Check workflow logs:** Ensure both registry logins succeed
+3. **Verify containers:** Check that containers appear in both registries:
+   - GHCR: `ghcr.io/karlssoc/ck-pybis-toolkit:latest`
+   - Quay.io: `quay.io/karlssoc/ck-pybis-toolkit:latest`
+
+## Troubleshooting
+
+### Authentication Failures
+- **Check secret names:** Ensure `QUAY_USERNAME` and `QUAY_PASSWORD` are exact
+- **Verify credentials:** Test login locally with `docker login quay.io`
+- **Token expiration:** Check if application tokens need renewal
+
+### Repository Permissions
+- **Repository exists:** Ensure `quay.io/karlssoc/ck-pybis-toolkit` repository exists
+- **Write access:** Verify the account has push permissions
+- **Public repository:** Ensure the repository is configured as public for deployment access
+
+### Workflow Failures
+- **Missing secrets:** Check that both secrets are properly configured
+- **Registry connectivity:** Verify GitHub Actions can reach quay.io
+- **Schema compatibility:** Ensure `provenance: false` is set in the workflow
+
+## Expected Results
+
+Once properly configured, the workflow will:
+
+1. **Login to both registries** during container builds
+2. **Generate tags for both** GHCR and Quay.io automatically
+3. **Push containers** to both registries simultaneously
+4. **Maintain compatibility** with Singularity v3.7 via Docker V2 Schema 2
+
+This enables seamless container distribution across both GitHub Container Registry and Quay.io for consistent deployment workflows.


### PR DESCRIPTION
## Summary

This PR implements dual registry mirroring to enable pushing containers to both GitHub Container Registry (GHCR) and Quay.io simultaneously, based on the GitHub Actions mirroring guide.

### Changes Made

- **Updated GitHub Actions workflow** (`.github/workflows/docker.yml`):
  - Added Quay.io authentication using repository secrets
  - Modified metadata extraction to generate tags for both registries
  - Maintained Docker V2 Schema 2 compatibility for Singularity v3.7
  - Added comprehensive comments for clarity

- **Added setup documentation** (`docs/QUAY_SECRETS_SETUP.md`):
  - Step-by-step instructions for configuring repository secrets
  - Security recommendations for token usage
  - Troubleshooting guide for common issues
  - Verification steps for testing the setup

### Key Features

✅ **Dual registry pushing** - Containers automatically pushed to both GHCR and Quay.io  
✅ **Seamless tagging** - Single metadata action generates tags for both registries  
✅ **Singularity compatibility** - Docker V2 Schema 2 format maintained  
✅ **Security best practices** - Uses repository secrets for authentication  
✅ **Comprehensive documentation** - Complete setup and troubleshooting guide  

### Benefits for CKS Ansible Integration

- **Consistent registry source** - All containers from `quay.io/karlssoc/*`
- **Public access** - No authentication required for Quay.io deployment
- **Automatic mirroring** - Updates automatically on source code changes
- **Enhanced compatibility** - Works with existing Singularity infrastructure

## Test Plan

- [ ] Configure repository secrets (`QUAY_USERNAME`, `QUAY_PASSWORD`)
- [ ] Test workflow on feature branch push
- [ ] Verify containers appear in both registries:
  - `ghcr.io/karlssoc/ck-pybis-toolkit:latest`
  - `quay.io/karlssoc/ck-pybis-toolkit:latest`
- [ ] Test Singularity compatibility with Quay.io images
- [ ] Update CKS Ansible deployment to use Quay.io mirror

🤖 Generated with [Claude Code](https://claude.ai/code)